### PR TITLE
Fix token label when GN and SN are missing in subject name

### DIFF
--- a/TokenData.cpp
+++ b/TokenData.cpp
@@ -161,7 +161,7 @@ QString TokenData::toHtml() const
 		else
 		{
 			s << tr("Name") << ": <font color=\"black\">"
-				<< c.toString( "GN SN" ) << "</font><br />";
+				<< c.toString( "CN" ) << "</font><br />";
 		}
 		if(!c.subjectInfo( "serialNumber" ).isEmpty())
 		{


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>