### PR TITLE
Output cmdline/file diagnostics when args provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,12 @@ qt5_wrap_ui( SOURCES AboutDialog.ui CertificateWidget.ui )
 list( APPEND SOURCES
 	AboutDialog.cpp
 	CertificateWidget.cpp
+	CliApplication.cpp
 	ComboBox.cpp
 	Common.cpp
 	DateTime.cpp
 	Diagnostics.cpp
+	DiagnosticsTask.cpp
 	IKValidator.cpp
 	PinDialog.cpp
 	QPCSC.cpp

--- a/CliApplication.cpp
+++ b/CliApplication.cpp
@@ -1,0 +1,60 @@
+/*
+ * QEstEidCommon
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include "CliApplication.h"
+#include "DiagnosticsTask.h"
+
+#include <iostream>
+#include <QtCore/QObject>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QTimer>
+
+
+CliApplication::CliApplication( int &argc, char **argv ) : argc(argc), argv(argv)
+{
+}
+
+CliApplication::CliApplication( int &argc, char **argv, QString outFile ) : CliApplication(argc, argv) 
+{
+	this->outFile = outFile;
+}
+
+bool CliApplication::isDiagnosticRun()
+{
+	for( size_t i = 1; i < argc; ++i )
+	{
+		auto parameter = QString( argv[i] );
+		if( parameter.startsWith("/diag") )
+		{
+			outFile = parameter.remove("/diag").remove(QRegExp("^[:]*"));
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int CliApplication::run() const
+{
+	QCoreApplication qtApp( argc, argv );
+	DiagnosticsTask *task = new DiagnosticsTask( &qtApp, outFile );
+	QObject::connect( task, SIGNAL(finished()), &qtApp, SLOT(quit()));
+
+	QTimer::singleShot( 0, task, SLOT(run()) );
+	return qtApp.exec();
+}

--- a/CliApplication.h
+++ b/CliApplication.h
@@ -19,26 +19,19 @@
 
 #pragma once
 
-#include <QtCore/QObject>
-#include <QtCore/QRunnable>
+#include <QString>
 
-class QTextStream;
-
-class Diagnostics: public QObject, public QRunnable
+class CliApplication
 {
-	Q_OBJECT
 public:
-	Diagnostics();
-	explicit Diagnostics( bool );
+	CliApplication( int &argc, char **argv );
+	CliApplication( int &argc, char **argv, QString outFile );
 
-	void run();
-
-signals:
-	void update( const QString &data );
+	bool isDiagnosticRun();
+	int run() const;
 
 private:
-	bool hasAppInfo;
-
-	void generalInfo(QTextStream &s) const;
-	void appInfo(QTextStream &s) const;
+	int &argc;
+	char **argv;
+	QString outFile;
 };

--- a/CliApplication.h
+++ b/CliApplication.h
@@ -20,18 +20,28 @@
 #pragma once
 
 #include <QString>
+#include <QTextStream>
 
-class CliApplication
+class CliApplication: public QObject
 {
+	Q_OBJECT
 public:
-	CliApplication( int &argc, char **argv );
-	CliApplication( int &argc, char **argv, QString outFile );
+	CliApplication( int &argc, char **argv, const QString &appName );
+	CliApplication( int &argc, char **argv, const QString &appName, const QString &outFile );
 
 	bool isDiagnosticRun();
 	int run() const;
 
+public slots:
+	void exit() const;
+
+
+protected:
+	virtual void diagnostics( QTextStream &s ) const;
+
 private:
 	int &argc;
 	char **argv;
+	QString appName;
 	QString outFile;
 };

--- a/Diagnostics.cpp
+++ b/Diagnostics.cpp
@@ -30,19 +30,24 @@
 #include <QtCore/QStringList>
 #include <QtCore/QTextStream>
 
-Diagnostics::Diagnostics() : hasAppInfo( true ), QObject( 0 )
+Diagnostics::Diagnostics() : QObject( 0 ), hasAppInfo( true )
 {
 }
 
-Diagnostics::Diagnostics(bool) : hasAppInfo( false ), QObject( 0 )
+Diagnostics::Diagnostics( const QString &appInfo )
+	: QObject( 0 ), hasAppInfo( false ), appInfoMsg( appInfo )
 {
 }
 
 void Diagnostics::appInfo(QTextStream &s) const
 {
-	if (hasAppInfo)
+	if( hasAppInfo )
 	{
 		qApp->diagnostics(s);
+	}
+	else if ( !appInfoMsg.isEmpty() )
+	{
+		s << appInfoMsg;
 	}
 }
 

--- a/Diagnostics.cpp
+++ b/Diagnostics.cpp
@@ -30,9 +30,26 @@
 #include <QtCore/QStringList>
 #include <QtCore/QTextStream>
 
+Diagnostics::Diagnostics() : hasAppInfo( true ), QObject( 0 )
+{
+}
+
+Diagnostics::Diagnostics(bool) : hasAppInfo( false ), QObject( 0 )
+{
+}
+
+void Diagnostics::appInfo(QTextStream &s) const
+{
+	if (hasAppInfo)
+	{
+		qApp->diagnostics(s);
+	}
+}
+
 void Diagnostics::generalInfo(QTextStream &s) const
 {
-	s << "<b>" << tr("Arguments:") << "</b> " << qApp->arguments().join(" ") << "<br />";
+	auto app = QCoreApplication::instance();
+	s << "<b>" << tr("Arguments:") << "</b> " << app->arguments().join(" ") << "<br />";
 	s << "<b>" << tr("Library paths:") << "</b> " << QCoreApplication::libraryPaths().join( ";" ) << "<br />";
 	s << "<b>" << "URLs:" << "</b>";
 #ifdef BREAKPAD
@@ -41,7 +58,7 @@ void Diagnostics::generalInfo(QTextStream &s) const
 #ifdef CONFIG_URL
 	s << "<br />CONFIG_URL: " << CONFIG_URL;
 #endif
-	qApp->diagnostics(s);
+	appInfo(s);
 	s << "<br /><br />";
 
 #ifdef CONFIG_URL

--- a/Diagnostics.h
+++ b/Diagnostics.h
@@ -29,7 +29,7 @@ class Diagnostics: public QObject, public QRunnable
 	Q_OBJECT
 public:
 	Diagnostics();
-	explicit Diagnostics( bool );
+	explicit Diagnostics( const QString &appInfo );
 
 	void run();
 
@@ -38,6 +38,7 @@ signals:
 
 private:
 	bool hasAppInfo;
+	QString appInfoMsg;
 
 	void generalInfo(QTextStream &s) const;
 	void appInfo(QTextStream &s) const;

--- a/DiagnosticsTask.cpp
+++ b/DiagnosticsTask.cpp
@@ -1,0 +1,75 @@
+/*
+ * QEstEidCommon
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+#include "DiagnosticsTask.h"
+
+#include <cstdio>
+#include <QFile>
+#include <QTextDocument>
+#include <QTextStream>
+
+
+DiagnosticsTask::DiagnosticsTask( QObject *parent, QString outFile ) : QObject(parent), outFile(outFile)
+{
+}
+
+void DiagnosticsTask::run()
+{
+	Diagnostics *worker = new Diagnostics( false );
+	QObject::connect( worker, &Diagnostics::update, this, &DiagnosticsTask::insertHtml );
+	worker->run();
+	complete();
+	logDiagnostics();
+
+	emit finished();
+}
+
+void DiagnosticsTask::logDiagnostics()
+{
+	QFile file( outFile );
+	if( outFile.isEmpty() )
+	{
+		file.open( stdout, QIODevice::WriteOnly );
+	}
+	else
+	{
+		file.open( QIODevice::WriteOnly );
+	}
+
+	QTextStream out( &file );
+	out << getDiagnostics();
+	out.flush();
+}
+
+QString DiagnosticsTask::getDiagnostics() const
+{
+	return data;
+}
+
+void DiagnosticsTask::insertHtml( const QString &text )
+{
+	html << text;
+}
+
+void DiagnosticsTask::complete()
+{
+	QTextDocument doc;
+	doc.setHtml( html.join("") );
+
+	data = doc.toPlainText();
+}

--- a/DiagnosticsTask.h
+++ b/DiagnosticsTask.h
@@ -22,11 +22,11 @@
 #include "Diagnostics.h"
 #include <QObject>
 
-class DiagnosticsTask : public QObject
+class DiagnosticsTask: public QObject
 {
 	Q_OBJECT
 public:
-	DiagnosticsTask(QObject *parent, QString outFile = "" );
+	DiagnosticsTask(QObject *parent, const QString &appInfo, const QString &outFile = "" );
 	QString getDiagnostics() const;
 	void complete();
 
@@ -36,11 +36,13 @@ public slots:
 
 signals:
 	void finished();
+	void failed();
 
 private:
 	QStringList html;
 	QString data;
 	QString outFile;
+	QString appInfo;
 
-	void logDiagnostics();
+	bool logDiagnostics();
 };

--- a/DiagnosticsTask.h
+++ b/DiagnosticsTask.h
@@ -19,26 +19,28 @@
 
 #pragma once
 
-#include <QtCore/QObject>
-#include <QtCore/QRunnable>
+#include "Diagnostics.h"
+#include <QObject>
 
-class QTextStream;
-
-class Diagnostics: public QObject, public QRunnable
+class DiagnosticsTask : public QObject
 {
 	Q_OBJECT
 public:
-	Diagnostics();
-	explicit Diagnostics( bool );
+	DiagnosticsTask(QObject *parent, QString outFile = "" );
+	QString getDiagnostics() const;
+	void complete();
 
+public slots:
 	void run();
+	void insertHtml( const QString &text );
 
 signals:
-	void update( const QString &data );
+	void finished();
 
 private:
-	bool hasAppInfo;
+	QStringList html;
+	QString data;
+	QString outFile;
 
-	void generalInfo(QTextStream &s) const;
-	void appInfo(QTextStream &s) const;
+	void logDiagnostics();
 };


### PR DESCRIPTION
IB-4480: Create commandline application that can be started without GUI.
Add application class to check provided parameters and output the diagnostics to file or shell.
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>