### PR TITLE
Show cert. CN as-is without capitalizing names

### DIFF
--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -108,24 +108,6 @@ QString SslCertificate::friendlyName() const
 	return cn;
 }
 
-QString SslCertificate::formatName( const QString &name )
-{
-	QString ret = name.toLower();
-	bool firstChar = true;
-	for( QString::iterator i = ret.begin(); i != ret.end(); ++i )
-	{
-		if( !firstChar && !i->isLetter() )
-			firstChar = true;
-
-		if( firstChar && i->isLetter() )
-		{
-			*i = i->toUpper();
-			firstChar = false;
-		}
-	}
-	return ret;
-}
-
 QSslCertificate SslCertificate::fromX509( Qt::HANDLE x509 )
 {
 	QByteArray der( i2d_X509( (X509*)x509, 0 ), 0 );
@@ -379,7 +361,7 @@ QString SslCertificate::toString( const QString &format ) const
 		ret.replace( pos, r.cap(0).size(), si );
 		pos += si.size();
 	}
-	return showCN() ? ret : formatName( ret );
+	return ret;
 }
 
 SslCertificate::CertType SslCertificate::type() const

--- a/SslCertificate.h
+++ b/SslCertificate.h
@@ -103,7 +103,6 @@ public:
 	CertType	type() const;
 	bool		validateEncoding() const;
 
-	static QString formatName( const QString &name );
 	static QSslCertificate fromX509( Qt::HANDLE x509 );
 	static QSslKey keyFromEVP( Qt::HANDLE evp );
 


### PR DESCRIPTION
IB-4547: Do not try to format/capitalize certificate CN in UI, use "as-is" because names
are not always capitalized uniformly (e.g. compound names with particles like Mac, Mc, von etc).
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>