### PR TITLE
Fix OSX crash in qdigidoc on multiple About clicks

### DIFF
--- a/Common.cpp
+++ b/Common.cpp
@@ -387,7 +387,6 @@ QStringList Common::packages( const QStringList &names, bool withName )
 		packages << QString("%1 (%2.%3)").arg(name)
 			.arg(QString::fromCFString(ver))
 			.arg(QString::fromCFString(build));
-		CFRelease(bundle);
 	}
 #elif defined(Q_OS_LINUX)
 	QProcess p;


### PR DESCRIPTION
IB-4520/When about menuitem is clicked multiple times, client crashes:
- bundle reference is unnecessarily released after CFBundleGetBundleWithIdentifier

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>