### PR TITLE
Save diagnostics to file in Win with \r\n symbols

### DIFF
--- a/AboutDialog.cpp
+++ b/AboutDialog.cpp
@@ -104,6 +104,6 @@ void AboutDialog::saveDiagnostics()
 	if( filename.isEmpty() )
 		return;
 	QFile f( filename );
-	if( !f.open( QIODevice::WriteOnly ) || !f.write( ui->diagnostics->toPlainText().toUtf8() ) )
+	if( !f.open( QIODevice::WriteOnly|QIODevice::Text ) || !f.write( ui->diagnostics->toPlainText().toUtf8() ) )
 		QMessageBox::warning( this, tr("Error occurred"), tr("Failed write to file!") );
 }

--- a/DiagnosticsTask.cpp
+++ b/DiagnosticsTask.cpp
@@ -60,7 +60,7 @@ bool DiagnosticsTask::logDiagnostics()
 	}
 	else
 	{
-		isOpened = file.open( QIODevice::WriteOnly );
+		isOpened = file.open( QIODevice::WriteOnly|QIODevice::Text );
 	}
 
 	if ( isOpened )


### PR DESCRIPTION
IB-4615: Open file with text attribute so that diagnostics info is written
to file on Windows with Windows newline (CR+LF).
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>