### PR TITLE
Reduce the width of token data for long names

### DIFF
--- a/TokenData.cpp
+++ b/TokenData.cpp
@@ -154,10 +154,14 @@ QString TokenData::toHtml() const
 	}
 	else
 	{
+		bool breakOnSerial = true;
 		if(!c.subjectInfo("GN").isEmpty() && !c.subjectInfo("SN").isEmpty())
 		{
-			s << tr("Name") << ": <font color=\"black\">"
-				<< c.toString( "GN SN" ) << "</font><br />";
+			s << tr("Given Names") << ": <font color=\"black\">"
+				<< c.toString( "GN" ) << "</font><br />";
+			s << tr("Surname") << ": <font color=\"black\">"
+				<< c.toString( "SN" ) << "</font><br />";
+			breakOnSerial = false;
 		}
 		else
 		{
@@ -167,7 +171,7 @@ QString TokenData::toHtml() const
 		if(!c.subjectInfo( "serialNumber" ).isEmpty())
 		{
 			s << tr("Personal code") << ": <font color=\"black\">"
-				<< c.subjectInfo( "serialNumber" ) << "</font><br />";
+				<< c.subjectInfo( "serialNumber" ) << "</font>" << ( breakOnSerial ? "<br />" : "&nbsp;&nbsp;" );
 		}
 	}
 	s << tr("Card in reader") << ": <font color=\"black\">" << d->card << "</font><br />";

--- a/translations/common_en.ts
+++ b/translations/common_en.ts
@@ -527,6 +527,14 @@ Additional licenses and components</translation>
         <translation>Name</translation>
     </message>
     <message>
+        <source>Given Names</source>
+        <translation>Given Names</translation>
+    </message>
+    <message>
+        <source>Surname</source>
+        <translation>Surname</translation>
+    </message>
+    <message>
         <source>Personal code</source>
         <translation>Personal code</translation>
     </message>

--- a/translations/common_et.ts
+++ b/translations/common_et.ts
@@ -527,6 +527,14 @@ Täiendavad litsentsid ja komponendid</translation>
         <translation>Nimi</translation>
     </message>
     <message>
+        <source>Given Names</source>
+        <translation>Eesnimed</translation>
+    </message>
+    <message>
+        <source>Surname</source>
+        <translation>Perekonnanimi</translation>
+    </message>
+    <message>
         <source>Personal code</source>
         <translation>Isikukood</translation>
     </message>

--- a/translations/common_ru.ts
+++ b/translations/common_ru.ts
@@ -527,6 +527,14 @@ Additional licenses and components</source>
         <translation>Имя</translation>
     </message>
     <message>
+        <source>Given Names</source>
+        <translation>Имя</translation>
+    </message>
+    <message>
+        <source>Surname</source>
+        <translation>Фамилия</translation>
+    </message>
+    <message>
         <source>Personal code</source>
         <translation>Личный код</translation>
     </message>

--- a/translations/common_ru.ts
+++ b/translations/common_ru.ts
@@ -568,7 +568,7 @@ Additional licenses and components</source>
     </message>
     <message>
         <source>Open utility</source>
-        <translation>Открыть средство управления</translation>
+        <translation>Открыть утилиту</translation>
     </message>
     <message>
         <source>Update</source>


### PR DESCRIPTION
IB-4614: Reduce the width of the token data if certificate's name is long:
- In card info display given names and surname on separate lines, serial and
  card no on the same line
- Decrease the width of "Open utility" link for Russian (alternative translation) in case of blocked PIN so that coat of arms is not covered by card info box.
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>