### PR TITLE
'Diagnostics->Application version' shows 32 or 64 bit compilation

### DIFF
--- a/Diagnostics_unix.cpp
+++ b/Diagnostics_unix.cpp
@@ -50,7 +50,7 @@ void Diagnostics::run()
 	if( !package.isEmpty() )
 		s << "<b>" << tr("Base version:") << "</b> " << package.first() << "<br />";
 #endif
-	s << "<b>" << tr("Application version:") << "</b> " << QCoreApplication::applicationVersion() << "<br />";
+	s << "<b>" << tr("Application version:") << "</b> " << QCoreApplication::applicationVersion() << " (" << QSysInfo::WordSize << " bit)<br />";
 	emit update( info );
 	info.clear();
 

--- a/Diagnostics_win.cpp
+++ b/Diagnostics_win.cpp
@@ -100,7 +100,7 @@ void Diagnostics::run()
 		"Eesti ID-kaardi tarkvara", "Estonian ID-card software", "eID software"}, false);
 	if( !base.isEmpty() )
 		s << "<b>" << tr("Base version:") << "</b> " << base.join( "<br />" ) << "<br />";
-	s << "<b>" << tr("Application version:") << "</b> "<< QCoreApplication::applicationVersion() << "<br />";
+	s << "<b>" << tr("Application version:") << "</b> " << QCoreApplication::applicationVersion() << " (" << QSysInfo::WordSize << " bit)<br />";
 	emit update( info );
 	info.clear();
 


### PR DESCRIPTION
In 'Diagnostics->Application version' show if application was compiled for
32 or 64 bit system.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>