### PR TITLE
Fix compiler warning

### DIFF
--- a/CliApplication.cpp
+++ b/CliApplication.cpp
@@ -71,7 +71,7 @@ int CliApplication::run() const
 	return qtApp.exec();
 }
 
-void CliApplication::diagnostics( QTextStream &s ) const
+void CliApplication::diagnostics( QTextStream & ) const
 {
 }
 


### PR DESCRIPTION
CliApplication.cpp:74:48: warning: unused parameter 's' [-Wunused-parameter]
void CliApplication::diagnostics( QTextStream &s ) const

Signed-off-by: Raul Metsma <raul@metsma.ee>