### PR TITLE
Detect certtype via policy or qcStatements extension

### DIFF
--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -21,6 +21,8 @@
 
 #include "qasn1element_p.h"
 
+#include <digidocpp/crypto/X509Cert.h>
+
 #include <QtCore/QDataStream>
 #include <QtCore/QDateTime>
 #include <QtCore/QFile>
@@ -428,13 +430,30 @@ SslCertificate::CertType SslCertificate::type() const
 			p.startsWith( "1.3.6.1.4.1.10015.3.11" ) )
 			return MobileIDTestType;
 		if( p.startsWith( "1.3.6.1.4.1.10015.3.7" ) ||
-			(p.startsWith( "1.3.6.1.4.1.10015.7.1" ) &&
+			((p.startsWith( "1.3.6.1.4.1.10015.7.1" ) ||
+			  p.startsWith( "1.3.6.1.4.1.10015.7.3" )) &&
 			 issuerInfo( QSslCertificate::CommonName ).indexOf( "TEST" ) != -1) )
 			return TempelTestType;
 
 		if( p.startsWith( "1.3.6.1.4.1.10015.7.1" ) ||
+			p.startsWith( "1.3.6.1.4.1.10015.7.3" ) ||
 			p.startsWith( "1.3.6.1.4.1.10015.2.1" ) )
 			return TempelType;
+	}
+
+	// Check qcStatements extension according to ETSI EN 319 412-5
+	QByteArray der = toDer();
+	if (!der.isNull())
+	{
+		digidoc::X509Cert x509Cert((const unsigned char*)der.constData(),
+			size_t(der.size()), digidoc::X509Cert::Der);
+		for(const std::string &statement: x509Cert.qcStatements())
+		{
+			if(statement == "0.4.0.1862.1.6.1")
+				return DigiIDType;
+			if(statement == "0.4.0.1862.1.6.2")
+				return TempelType;
+		}
 	}
 	return UnknownType;
 }

--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -452,9 +452,9 @@ SslCertificate::CertType SslCertificate::type() const
 			size_t(der.size()), digidoc::X509Cert::Der);
 		for(const std::string &statement: x509Cert.qcStatements())
 		{
-			if(statement == X509Cert::QCT_ESIGN)
+			if(statement == digidoc::X509Cert::QCT_ESIGN)
 				return DigiIDType;
-			if(statement == X509Cert::QCT_ESEAL)
+			if(statement == digidoc::X509Cert::QCT_ESEAL)
 				return TempelType;
 		}
 	}

--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -21,7 +21,9 @@
 
 #include "qasn1element_p.h"
 
+#ifdef LIBDIGIDOCPP
 #include <digidocpp/crypto/X509Cert.h>
+#endif
 
 #include <QtCore/QDataStream>
 #include <QtCore/QDateTime>
@@ -441,6 +443,7 @@ SslCertificate::CertType SslCertificate::type() const
 			return TempelType;
 	}
 
+#ifdef LIBDIGIDOCPP
 	// Check qcStatements extension according to ETSI EN 319 412-5
 	QByteArray der = toDer();
 	if (!der.isNull())
@@ -455,6 +458,7 @@ SslCertificate::CertType SslCertificate::type() const
 				return TempelType;
 		}
 	}
+#endif
 	return UnknownType;
 }
 

--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -452,9 +452,9 @@ SslCertificate::CertType SslCertificate::type() const
 			size_t(der.size()), digidoc::X509Cert::Der);
 		for(const std::string &statement: x509Cert.qcStatements())
 		{
-			if(statement == "0.4.0.1862.1.6.1")
+			if(statement == X509Cert::QCT_ESIGN)
 				return DigiIDType;
-			if(statement == "0.4.0.1862.1.6.2")
+			if(statement == X509Cert::QCT_ESEAL)
 				return TempelType;
 		}
 	}

--- a/SslCertificate.cpp
+++ b/SslCertificate.cpp
@@ -21,7 +21,7 @@
 
 #include "qasn1element_p.h"
 
-#ifdef LIBDIGIDOCPP
+#ifndef NO_LIBDIGIDOCPP
 #include <digidocpp/crypto/X509Cert.h>
 #endif
 
@@ -443,7 +443,7 @@ SslCertificate::CertType SslCertificate::type() const
 			return TempelType;
 	}
 
-#ifdef LIBDIGIDOCPP
+#ifndef NO_LIBDIGIDOCPP
 	// Check qcStatements extension according to ETSI EN 319 412-5
 	QByteArray der = toDer();
 	if (!der.isNull())


### PR DESCRIPTION
IB-5192:
- Add SK policy 1.3.6.1.4.1.10015.7.3 = TempelType
- Detect type via ETSI EN 319 412-5 qcStatements extension if type not
  detected via policy id

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>