### PR TITLE
Fix building with Qt 5.11

### DIFF
--- a/qtsingleapplication/CMakeLists.txt
+++ b/qtsingleapplication/CMakeLists.txt
@@ -3,7 +3,4 @@ if( WIN32 )
 endif()
 add_library( qtsingleapplication STATIC src/qtlocalpeer.cpp src/qtsingleapplication.cpp )
 set_target_properties( qtsingleapplication PROPERTIES AUTOMOC TRUE )
-
-if( Qt5Widgets_FOUND )
-	qt5_use_modules( qtsingleapplication Widgets Network )
-endif()
+target_link_libraries( qtsingleapplication Qt5::Widgets Qt5::Network )


### PR DESCRIPTION
`qt5_use_modules` has been declared obsolete since at least Qt 5.5 and was removed
in Qt 5.11. Qt documentations suggests using `target_link_libraries` instead.
http://doc.qt.io/qt-5/cmake-manual.html#qt5core-macros