### PR TITLE
Parse /etc/os-release for compatibility with Fedora

### DIFF
--- a/Common.cpp
+++ b/Common.cpp
@@ -114,9 +114,9 @@ QString Common::applicationOs()
 {
 #if defined(Q_OS_LINUX)
 	QProcess p;
-	p.start("lsb_release", { "-s", "-d" });
+	p.start("bash", { "-c", "cat /etc/os-release | grep PRETTY | cut -d'\"' -f2" });
 	p.waitForFinished();
-	return QString::fromLocal8Bit( p.readAll().trimmed() );
+	return QString("Linux/") + QString::fromLocal8Bit(p.readAll().trimmed());
 #elif defined(Q_OS_MAC)
 	struct utsname unameData;
 	uname( &unameData );

--- a/Common.cpp
+++ b/Common.cpp
@@ -27,6 +27,7 @@
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
 #include <QtCore/QProcess>
+#include <QtCore/QSysInfo>
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
 #include <QtCore/QUrlQuery>
@@ -113,10 +114,7 @@ Common::Common( int &argc, char **argv, const QString &app, const QString &icon 
 QString Common::applicationOs()
 {
 #if defined(Q_OS_LINUX)
-	QProcess p;
-	p.start("bash", { "-c", "cat /etc/os-release | grep PRETTY | cut -d'\"' -f2" });
-	p.waitForFinished();
-	return QString("Linux/") + QString::fromLocal8Bit(p.readAll().trimmed());
+	return QStringLiteral("Linux/") + QSysInfo::prettyProductName();
 #elif defined(Q_OS_MAC)
 	struct utsname unameData;
 	uname( &unameData );


### PR DESCRIPTION
`/etc/os-release` is provided by `systemd` and `lsb_release` is not
installed by default on this Linux flavor.

    ~ cat /etc/os-release | grep PRETTY | cut -d'"' -f2
    Fedora 28 (Workstation Edition)

Fixes #74.