### PR TITLE
Remove DWORD cast to fix build on OpenBSD/i386

### DIFF
--- a/QPCSC.cpp
+++ b/QPCSC.cpp
@@ -513,7 +513,7 @@ bool QPCSCReader::updateState( quint32 msec )
 	if(!d->d->context)
 		return false;
 	d->state.dwCurrentState = d->state.dwEventState;
-	switch(DWORD(SC(GetStatusChange, d->d->context, msec, &d->state, 1U))) //INFINITE
+	switch(SC(GetStatusChange, d->d->context, msec, &d->state, 1U))
 	{
 	case SCARD_S_SUCCESS: return true;
 	case SCARD_E_TIMEOUT: return msec == 0;


### PR DESCRIPTION
`SC` defined as `LONG SCall(...)` returns `LONG` typed PCSC error codes.

Casting these values to `DWORD` in a switch statement only to compare
them to literal error codes again is unneeded and breaks the build on
32-bit i386:

```
/pobj/qdigidoc4-4.2.11/qdigidoc4/common/QPCSC.cpp:519:7: error: case value evaluates to -2146435062, which cannot be narrowed to type 'DWORD' (aka 'unsigned long') [-Wc++11-narrowing]
       case SCARD_E_TIMEOUT: return msec == 0;
            ^
/usr/local/include/PCSC/pcsclite.h:127:27: note: expanded from macro 'SCARD_E_TIMEOUT'
#define SCARD_E_TIMEOUT                 ((LONG)0x8010000A) /**< The user-specified timeout value has expired. */
        ^
1 error generated.
```

Signed-off-by: Klemens Nanni <klemens@posteo.de>